### PR TITLE
修复默认值如果是“["100000"]”的话，没有被设置上

### DIFF
--- a/src/components/region-picker.vue
+++ b/src/components/region-picker.vue
@@ -89,6 +89,10 @@ function createMap(country) {
     return object;
   }
 
+  FLATTEN_MAP.push({
+    fullName: country.name,
+    place: country,
+  });
   const MAP = traverse(country, 0);
   return {
     MAP,


### PR DESCRIPTION
如下代码，之前保存的默认已选择的地域是“全国”，但UI上没有把这个值展现出来。
````html
<div id="app">
  <region-picker v-model="selectedRegion" :data="regionData" multiple></region-picker>
</div>
````
````js
new Vue({
  el: document.getElementById("app"),
  data: function() {
    return {
      selectedRegion: ["100000"],
      regionData: require("./dist/data.json")
    }
  }
})
````

我的修改办法是`FLATTEN_MAP`中塞入全国，这样就可以了。